### PR TITLE
add vmess Aead Force to false  for ios connections

### DIFF
--- a/x-ui.service
+++ b/x-ui.service
@@ -4,7 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
-Environment="xray.vmess.aead.forced=false"
+Environment="XRAY_VMESS_AEAD_FORCED=false"
 Type=simple
 WorkingDirectory=/usr/local/x-ui/
 ExecStart=/usr/local/x-ui/x-ui


### PR DESCRIPTION
add vmess Aead Force to false  for ios connections
in xray core version > 1.4.0 some ios clients cant connect to vmess cause of vmess Aead.